### PR TITLE
RazorMachine does not work with Razor 3.0

### DIFF
--- a/Source/Xipton.Razor/Core/Generator/SetModelCodeGenerator.cs
+++ b/Source/Xipton.Razor/Core/Generator/SetModelCodeGenerator.cs
@@ -30,7 +30,7 @@ namespace Xipton.Razor.Core.Generator
 
             #region Work Around
             if (!(context.Host.CodeLanguage is VBRazorCodeLanguage)) 
-                context.GeneratedClass.LinePragma = context.GenerateLinePragma(target, CalculatePadding(target, 0));
+                context.GeneratedClass.LinePragma = context.GenerateLinePragma(target, CalculateSpanPadding(target, 0));
             //else
                 // exclude VBRazorCodeLanguage
                 // with VB I found a problem with the #End ExternalSource directive rendered at the GeneratedClass's end while it should not be rendered
@@ -63,6 +63,14 @@ namespace Xipton.Razor.Core.Generator
         public override int GetHashCode()
         {
             return ModelType.GetHashCode();
+        }
+
+        private int CalculateSpanPadding(Span target, int generatedStart)
+        {
+            int num = target.Start.CharacterIndex - generatedStart;
+            if (num < 0)
+                num = 0;
+            return num;
         }
     }
 }


### PR DESCRIPTION
When running with ASP.NET MVC default Razor engine, which is version 3.0 an error is thrown as the CalculatePadding no longer exists (neither does the base class that Span had that declared it).

I've added the method's implementation to the class with new name so it should now work with both Razor 2.0 and 3.0. Tested with Razor 3.0 and works now nicely with our templates.

Would appreciate an updated NuGet package.

Thanks for the great work you are doing with the project!
