### PR TITLE
fix loading dlls with bad paths like edgejs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ TestResults
 ###################
 *.user
 *.suo
-
+*.vs
 
 # Logs and databases #
 ######################

--- a/Source/Xipton.Razor.Example/App.config
+++ b/Source/Xipton.Razor.Example/App.config
@@ -45,4 +45,4 @@
       </xipton.razor>
   </xipton.razor.config>
 
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>

--- a/Source/Xipton.Razor.Example/Xipton.Razor.Example.csproj
+++ b/Source/Xipton.Razor.Example/Xipton.Razor.Example.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Xipton.Razor.Example</RootNamespace>
     <AssemblyName>Xipton.Razor.Example</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
@@ -40,8 +40,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.3\lib\net45\System.Web.Razor.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.5\lib\net45\System.Web.Razor.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.CSharp" />

--- a/Source/Xipton.Razor.Example/packages.config
+++ b/Source/Xipton.Razor.Example/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Razor" version="3.2.5" targetFramework="net45" />
 </packages>

--- a/Source/Xipton.Razor.UnitTest/App.config
+++ b/Source/Xipton.Razor.UnitTest/App.config
@@ -40,4 +40,4 @@
       </xipton.razor>
   </xipton.razor.config>
 
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>

--- a/Source/Xipton.Razor.UnitTest/Xipton.Razor.UnitTest.csproj
+++ b/Source/Xipton.Razor.UnitTest/Xipton.Razor.UnitTest.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Xipton.Razor.UnitTest</RootNamespace>
     <AssemblyName>Xipton.Razor.UnitTest</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
@@ -40,8 +40,7 @@
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.3\lib\net45\System.Web.Razor.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.5\lib\net45\System.Web.Razor.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.CSharp" />
@@ -62,10 +61,10 @@
     <None Include="App.config">
       <SubType>Designer</SubType>
     </None>
-    <None Include="packages.config" />
     <None Include="legacy\web.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xipton.Razor\Xipton.Razor.csproj">

--- a/Source/Xipton.Razor.UnitTest/packages.config
+++ b/Source/Xipton.Razor.UnitTest/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Razor" version="3.2.5" targetFramework="net45" />
 </packages>

--- a/Source/Xipton.Razor.nuspec
+++ b/Source/Xipton.Razor.nuspec
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>reactiveui-core</id>
+    <version>3.1.0</version>
+    <description>Razor machine</description>
+    <authors>jlamfers</authors>
+    <projectUrl>https://github.com/jlamfers/RazorMachine</projectUrl>
+    <licenseUrl>http://opensource.org/licenses/ms-pl.html</licenseUrl>
+    <language>en-us</language>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+  </metadata>
+  <files>
+    <file src="Xipton.Razor\bin\release\*.dll" target="lib" />
+  </files>
+</package>

--- a/Source/Xipton.Razor.nuspec
+++ b/Source/Xipton.Razor.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>reactiveui-core</id>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
     <description>Razor machine</description>
     <authors>jlamfers</authors>
     <projectUrl>https://github.com/jlamfers/RazorMachine</projectUrl>

--- a/Source/Xipton.Razor/Config/RazorConfig.cs
+++ b/Source/Xipton.Razor/Config/RazorConfig.cs
@@ -325,7 +325,7 @@ namespace Xipton.Razor.Config {
                 referencedAssemblyFileNames.AddRange(
                     domainAssemblies
                     .Select(assembly => assembly.GetFileName())
-                    .Where(filename => filename.EndsWith(pattern.Substring(1), StringComparison.OrdinalIgnoreCase))
+                    .Where(filename => filename != null && filename.EndsWith(pattern.Substring(1), StringComparison.OrdinalIgnoreCase))
                 );
             }
         }

--- a/Source/Xipton.Razor/Extension/AssemblyExtension.cs
+++ b/Source/Xipton.Razor/Extension/AssemblyExtension.cs
@@ -15,16 +15,23 @@ namespace Xipton.Razor.Extension
     {
         public static string GetFileName(this Assembly assembly)
         {
-
+            try
+            {
 #if __MonoCS__
             return assembly == null 
                 ? null
                 : new DirectoryInfo(IsNotWindows ? assembly.CodeBase.Replace("file:///", "/") : assembly.CodeBase.Replace("file:///", string.Empty)).FullName;
 #else
-            return assembly == null
-                ? null
-                : new DirectoryInfo(assembly.CodeBase.Replace("file:///", string.Empty)).FullName;
+                return assembly == null || assembly.CodeBase.Contains("?")
+                    ? null
+                    : new DirectoryInfo(assembly.CodeBase.Replace("file:///", string.Empty)).FullName;
 #endif
+
+            }
+            catch(Exception ex)
+            {
+                throw new Exception(assembly.CodeBase);
+            }
 
         }
 

--- a/Source/Xipton.Razor/Xipton.Razor.csproj
+++ b/Source/Xipton.Razor/Xipton.Razor.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Xipton.Razor</RootNamespace>
     <AssemblyName>Xipton.Razor</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -45,8 +45,7 @@
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.3\lib\net45\System.Web.Razor.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.5\lib\net45\System.Web.Razor.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.CSharp" />
@@ -110,10 +109,10 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <SubType>Designer</SubType>
     </None>
-    <None Include="packages.config" />
     <None Include="legacy\web.config">
       <SubType>Designer</SubType>
     </None>
+    <None Include="packages.config" />
     <None Include="Xipton.Razor.Overview.cd" />
   </ItemGroup>
   <ItemGroup />

--- a/Source/Xipton.Razor/packages.config
+++ b/Source/Xipton.Razor/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Razor" version="3.2.5" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
We have been using razormachine with no issue on many projects (and we have baked it into our framework).

But one of our projects is using edgejs for react server rendering and razormachine chokes on trying to load that dll due to a weird path with a question mark in it.
