### PR TITLE
Fixed bug preventing RazorMachine from running off a network drive

### DIFF
--- a/Source/Xipton.Razor/Extension/AssemblyExtension.cs
+++ b/Source/Xipton.Razor/Extension/AssemblyExtension.cs
@@ -21,9 +21,10 @@ namespace Xipton.Razor.Extension
                 ? null
                 : new DirectoryInfo(IsNotWindows ? assembly.CodeBase.Replace("file:///", "/") : assembly.CodeBase.Replace("file:///", string.Empty)).FullName;
 #else
-            return assembly == null
-                ? null
-                : new DirectoryInfo(assembly.CodeBase.Replace("file:///", string.Empty)).FullName;
+            if (assembly == null) return null;
+            var path = assembly.CodeBase.Replace("file:///", string.Empty);
+            path = path.Replace("file://", "//"); // Network drive locations (e.g. \\NetworkLocation\App) have a slightly different format which we will account for here
+            return new DirectoryInfo(path).FullName;
 #endif
 
         }


### PR DESCRIPTION
This bug was encountered when using RazorMachine in an application running off a network drive.

Network drive paths are formatted a bit differently, and the AssemblyExtension class was not handling assemblies with filepaths using this alternate format.